### PR TITLE
use spaCy lemma as fallback instead of token.text

### DIFF
--- a/spacy_spanish_lemmatizer/lemmatizer.py
+++ b/spacy_spanish_lemmatizer/lemmatizer.py
@@ -5,7 +5,6 @@ from .config import Config
 class Lemmatizer:
 
     def __init__(self):
-
         self.__lookup_table = {}
         self.__rules = {}
         with open(Config.OUTPUT_FILE, encoding="utf-8") as json_file:
@@ -13,12 +12,19 @@ class Lemmatizer:
         with open(Config.COMMON_RULES, encoding="utf-8") as json_file:
             self.__rules = json.load(json_file)
 
-    def __call__(self, token, pos):
+    def __call__(self, token, pos, old_lemma):
         pos = pos.lower()
         token = token.lower()
+        # hard lookup
+        lookup_data = self.__lookup_table.get(pos, {})
+        lookup = lookup_data.get(token, None)
+        if lookup:
+            return lookup
+        # general rules
         current_rules = self.__rules.get(pos, {})
         for old, new in current_rules.items():
             if token.endswith(old):
                 return token[: len(token)-len(old)] + new
-        current_exceptions = self.__lookup_table.get(pos.lower(), {})
-        return current_exceptions.get(token, token)
+        # use lemma from spaCy
+        return old_lemma.lower()
+

--- a/spacy_spanish_lemmatizer/main.py
+++ b/spacy_spanish_lemmatizer/main.py
@@ -5,5 +5,5 @@ class SpacyCustomLemmatizer(object):
     def __call__(self, doc):
         lemmatizer = Lemmatizer()
         for token in doc:
-            token.lemma_ = lemmatizer(token.text, token.pos_)
+            token.lemma_ = lemmatizer(token.text, token.pos_, token.lemma_)
         return doc


### PR DESCRIPTION
Hi, thank you for the repo!
I use the old lemma from spaCy as a fallback instead of the plain token.text which has better results in my experience.
By using the lookup before the verb rules we have better results with irregular verbs.